### PR TITLE
Upload resume TypeScript error fixes

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -88,9 +88,9 @@ export async function POST(req: NextRequest) {
     }
 
     const formData = await req.formData();
-    const file = formData.get('file') as Blob;
+    const file = formData.get('file');
 
-    if (!file) {
+    if (!(file instanceof File)) {
       return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
     }
 
@@ -100,6 +100,10 @@ export async function POST(req: NextRequest) {
 
     let rawText = '';
 
+    if (!ext) {
+      // ext is either of type 'string' or 'undefined'
+      return NextResponse.json({ error: 'Unsupported file type' }, { status: 415 });
+    }
     if (ext === 'pdf') {
       // const pdfParse = (await import('pdf-parse')).default;
       const result = await pdfParse(buffer);

--- a/src/app/home/upload-resume/page.tsx
+++ b/src/app/home/upload-resume/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useRef, useState, useEffect } from "react";
-import { FileUpload, FileUploadFile, FileUploadSelectEvent } from "primereact/fileupload";
+import { FileUpload, FileUploadSelectEvent, ItemTemplateOptions } from "primereact/fileupload";
 import { Button } from "primereact/button";
 import { getAIResponse, saveAIResponse, AIPrompt } from "@/components/ai/aiPrompt";
 import { db } from "@/lib/firebase";
@@ -138,7 +138,10 @@ export default function UploadResumePage() {
     setUploadProgress(0);
   };
 
-  const itemTemplate = (file, props) => (
+  const itemTemplate = (
+    file: { [key: string]: any },
+    options: ItemTemplateOptions
+  ) => (
     <div className="flex items-center justify-between p-3 border rounded-md w-full bg-white dark:bg-stone-800 mt-2">
       <div className="flex items-center gap-3">
         <i className="pi pi-file" style={{ fontSize: "1.5rem" }}></i>
@@ -158,7 +161,7 @@ export default function UploadResumePage() {
         <Button
           icon="pi pi-times"
           className="p-button-sm p-button-danger p-button-text"
-          onClick={() => onRemove(file, props.onRemove)}
+          onClick={options.onRemove}
         />
       </div>
     </div>

--- a/src/app/home/upload-resume/page.tsx
+++ b/src/app/home/upload-resume/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useRef, useState, useEffect } from "react";
-import { FileUpload } from "primereact/fileupload";
+import { FileUpload, FileUploadFile, FileUploadSelectEvent } from "primereact/fileupload";
 import { Button } from "primereact/button";
 import { getAIResponse, saveAIResponse, AIPrompt } from "@/components/ai/aiPrompt";
 import { db } from "@/lib/firebase";
@@ -24,7 +24,7 @@ export default function UploadResumePage() {
     return <p>Loading...</p>; // Show a loading state while checking auth
   }
 
-  const fileUploadRef = useRef(null);
+  const fileUploadRef = useRef<FileUpload>(null);
 
   const [uploadMessage, setUploadMessage] = useState<string | null>(null);
   const [uploadSuccess, setUploadSuccess] = useState<boolean | null>(null);
@@ -106,16 +106,20 @@ export default function UploadResumePage() {
     }
   };
 
-  const onRemove = (file, callback) => {
+  const onRemove = (file: File, callback: () => void) => {
     callback();
     setUploadMessage(null);
     setExtractedText(null);
   };
 
-  const onSelect = (e) => {
+  const onSelect = (e: FileUploadSelectEvent) => {
     const allowedExtensions = ["pdf", "docx", "txt", "md", "odt", "PDF", "DOCX", "TXT", "ODT"];
     const isValid = e.files.every((file) => {
       const ext = file.name.split(".").pop()?.toLowerCase();
+      // ext might be of type 'undefined' instead of 'string'
+      if (!ext) {
+        return false;
+      }
       return allowedExtensions.includes(ext);
     });
 

--- a/src/types/pdf-parse.d.ts
+++ b/src/types/pdf-parse.d.ts
@@ -1,0 +1,13 @@
+declare module 'pdf-parse/lib/pdf-parse.js' {
+    function pdfParse(buffer: Buffer): Promise<{
+        text: string;
+        numpages?: number;
+        numrender?: number;
+        info?: Record<string, any>;
+        metadata?: any;
+        version?: string;
+        [key: string]: any;
+    }>;
+
+    export default pdfParse;
+}

--- a/src/types/unzipper.d.ts
+++ b/src/types/unzipper.d.ts
@@ -1,0 +1,12 @@
+declare module 'unzipper' {
+    export namespace Open {
+        function buffer(
+            buffer: Buffer
+        ): Promise<{
+            files: Array<{
+                path: string;
+                buffer(): Promise<Buffer>;
+            }>;
+        }>;
+    }
+}


### PR DESCRIPTION
Relevant Jira Tickets:

1. (SCRUM-125) Fix the errors from VS Code on the 'Upload Resume' page
2. (SCRUM-126) Fix the errors from VS Code on the 'route.ts' file

Resolved errors from VS Code in `src/app/home/upload-resume/page.tsx`:

1. Property 'getFiles' does not exist on type 'never'. (Line 39)
2. Parameter 'file' implicitly has an 'any' type. (Line 109)
3. Parameter 'callback' implicitly has an 'any' type. (Line 109)
4. Parameter 'e' implicitly has an 'any' type. (Line 115)
5. Parameter 'file' implicitly has an 'any' type. (Line 117)
6. Property 'clear' does not exist on type 'never'. (Line 125)
7. Parameter 'file' implicitly has an 'any' type. (Line 137)
8. Parameter 'props' implicitly has an 'any' type. (Line 137)

Resolved errors from VS Code in `src/app/api/upload/route.ts`:

1. Could not find a declaration file for module 'unzipper'. '/home/bassil/Documents/NJIT/Summer_2025/pisces-cs490-project-summer-2025/node_modules/unzipper/unzip.js' implicitly has an 'any' type. Try `npm i --save-dev @types/unzipper` if it exists or add a new declaration (.d.ts) file containing `declare module 'unzipper';`
2. Could not find a declaration file for module 'pdf-parse/lib/pdf-parse.js'. '/home/bassil/Documents/NJIT/Summer_2025/pisces-cs490-project-summer-2025/node_modules/pdf-parse/lib/pdf-parse.js' implicitly has an 'any' type. Try `npm i --save-dev @types/pdf-parse` if it exists or add a new declaration (.d.ts) file containing `declare module 'pdf-parse/lib/pdf-parse.js';`
3. Parameter 'f' implicitly has an 'any' type.
4. Property 'name' does not exist on type 'Blob'.