### PR TITLE
Branch Chidi - 06/27/2025 --  Updated all input form pages to check for unsaved changes and display message if pages are unsaved (via popup and visual page message) and a page exit is tried

### DIFF
--- a/src/app/home/edit-education/page.tsx
+++ b/src/app/home/edit-education/page.tsx
@@ -23,6 +23,7 @@ type EducationFormProps = {
 function EducationForm({ educationList, setEducationList, user }: EducationFormProps) {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formChanged, setFormChanged] = useState(false); //for unsaved changes check
 
   function moveEduUp(index: number) {
     if (index === 0) return;
@@ -61,7 +62,6 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
       };
       newEduList.push(entry);
     }
-
     submitEduList(newEduList);
   }
 
@@ -72,6 +72,7 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
       const newEduRef = doc(db, "users", user.uid);
       await updateDoc(newEduRef, { "resumeFields.education": newEduList });
       setStatusMessage("Saved!");
+      setFormChanged(false);
       setTimeout(() => setStatusMessage(null), 2000);
     } catch (error) {
       setStatusMessage("Failed to save.");
@@ -92,6 +93,53 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
     setEducationList((oldEdu) => oldEdu.filter((_, i) => i !== index));
   }
 
+  useEffect(() => {
+    //handles reload and close tab if there are unsaved changes
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (formChanged) {
+        event.preventDefault();
+        event.returnValue = ''; //is deprecated but might be necessary to prompt on Chrome
+      }
+    };
+
+    //handles (most) clicks on links within the page if there are unsaved changes
+    const handleClick = (event: MouseEvent) => {
+      if (!formChanged) return;
+
+      const nav = document.querySelector('nav');
+      if (nav && nav.contains(event.target as Node)) {
+        const target = (event.target as HTMLElement).closest('a');
+        if (target && target instanceof HTMLAnchorElement) {
+          const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+        }
+      }
+
+      const header = document.querySelector('header');
+      if (header && header.contains(event.target as Node)) {
+        const target = (event.target as HTMLElement).closest('a');
+        if (target && target instanceof HTMLAnchorElement) {
+          const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+        }
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('click', handleClick, true);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [formChanged]);
+
   return (
     <div>
       <form method="post" onSubmit={handleSubmit}>
@@ -109,6 +157,8 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
                 const list = [...educationList];
                 list[index] = updated;
                 setEducationList(list);
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to save!");
               }}
               className="mb-2 w-full p-2 border rounded"
             />
@@ -124,6 +174,8 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
                 const list = [...educationList];
                 list[index] = updated;
                 setEducationList(list);
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to save!");
               }}
               className="mb-2 w-full p-2 border rounded"
             />
@@ -141,6 +193,8 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
                 const list = [...educationList];
                 list[index] = updated;
                 setEducationList(list);
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to save!");
               }}
               className="mb-2 w-full p-2 border rounded"
             />
@@ -158,6 +212,8 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
                 const list = [...educationList];
                 list[index] = updated;
                 setEducationList(list);
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to save!");
               }}
               className="mb-2 w-full p-2 border rounded"
             />
@@ -173,6 +229,8 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
                 const list = [...educationList];
                 list[index] = updated;
                 setEducationList(list);
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to save!");                
               }}
               className="mb-2 w-full p-2 border rounded"
             />
@@ -181,6 +239,8 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
                 onClick={(e) => {
                   e.preventDefault();
                   moveEduUp(index);
+                  setFormChanged(true);
+                  setStatusMessage("There has been a change. Don't forget to save!");
                 }}
                 className="bg-gray-500 text-white px-3 py-1 rounded hover:bg-gray-600 disabled:opacity-50 cursor-pointer"
                 disabled={index === 0}
@@ -191,6 +251,8 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
                 onClick={(e) => {
                   e.preventDefault();
                   moveEduDown(index);
+                  setFormChanged(true);
+                  setStatusMessage("There has been a change. Don't forget to save!");
                 }}
                 className="bg-gray-500 text-white px-3 py-1 rounded hover:bg-gray-600 disabled:opacity-50 cursor-pointer"
                 disabled={index === educationList.length - 1}
@@ -200,13 +262,18 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
             </div>
 
             <button
-              onClick={(event) => removeEdu(event, index)}
+              onClick={(event) => {
+                removeEdu(event, index);
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to save!");
+              }}
               className="bg-red-500 text-white px-3 py-1 mt-2 rounded hover:bg-red-600 cursor-pointer"
             >
               Remove
             </button>
           </div>
         ))}
+        {statusMessage == "There has been a change. Don't forget to save!" && <p className="mt-2 text-sm text-yellow-400">{statusMessage}</p>}
         <button
           onClick={addNewEdu}
           className="bg-blue-500 text-white px-4 py-2 mt-4 rounded hover:bg-blue-600 cursor-pointer"
@@ -221,7 +288,8 @@ function EducationForm({ educationList, setEducationList, user }: EducationFormP
         >
           {isSubmitting ? "Saving..." : "Save"}
         </button>
-        {statusMessage && <p className="mt-2 text-sm text-green-700">{statusMessage}</p>}
+        {statusMessage == "Saved!" && <p className="mt-2 text-sm text-green-700">{statusMessage}</p>}
+        {statusMessage == "Failed to save." && <p className="mt-2 text-sm text-red-600">{statusMessage}</p>}
       </form>
     </div>
   );
@@ -231,7 +299,7 @@ export default function EditEducationPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
   const [education, setEducation] = useState<EducationEntry[]>([]);
-
+  
   useEffect(() => {
     if (!loading && user) {
       getEducation().then((arr: EducationEntry[]) => {

--- a/src/app/home/edit-skills/page.tsx
+++ b/src/app/home/edit-skills/page.tsx
@@ -15,6 +15,7 @@ type SkillsFormProps = {
 function SkillsForm({ skillsList, setSkillsList, user }: SkillsFormProps) {
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formChanged, setFormChanged] = useState(false); //for unsaved changes check
 
   function moveSkillUp(index: number) {
     if (index === 0) return;
@@ -38,6 +39,7 @@ function SkillsForm({ skillsList, setSkillsList, user }: SkillsFormProps) {
       const newSkillsRef = doc(db, "users", user.uid);
       await updateDoc(newSkillsRef, { "resumeFields.skills": skills });
       setStatusMessage("Saved!");
+      setFormChanged(false);
       setTimeout(() => setStatusMessage(null), 2000);
     } catch (error) {
       setStatusMessage("Failed to save.");
@@ -75,6 +77,53 @@ function SkillsForm({ skillsList, setSkillsList, user }: SkillsFormProps) {
     );
   }
 
+  useEffect(() => {
+    //handles reload and close tab if there are unsaved changes
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (formChanged) {
+        event.preventDefault();
+        event.returnValue = ''; //is deprecated but might be necessary to prompt on Chrome
+      }
+    };
+
+    //handles (most) clicks on links within the page if there are unsaved changes
+    const handleClick = (event: MouseEvent) => {
+      if (!formChanged) return;
+
+      const nav = document.querySelector('nav');
+      if (nav && nav.contains(event.target as Node)) {
+        const target = (event.target as HTMLElement).closest('a');
+        if (target && target instanceof HTMLAnchorElement) {
+          const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+        }
+      }
+
+      const header = document.querySelector('header');
+      if (header && header.contains(event.target as Node)) {
+        const target = (event.target as HTMLElement).closest('a');
+        if (target && target instanceof HTMLAnchorElement) {
+          const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+        }
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('click', handleClick, true);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [formChanged]);
+
   return (
     <div>
       <form method="post" onSubmit={handleSubmit}>
@@ -85,6 +134,8 @@ function SkillsForm({ skillsList, setSkillsList, user }: SkillsFormProps) {
                 onClick={(e) => {
                   e.preventDefault();
                   moveSkillUp(index);
+                  setFormChanged(true);
+                  setStatusMessage("There has been a change. Don't forget to save!");
                 }}
                 className="bg-gray-400 text-white px-2 rounded hover:bg-gray-500 disabled:opacity-50 cursor-pointer"
                 disabled={index === 0}
@@ -96,6 +147,8 @@ function SkillsForm({ skillsList, setSkillsList, user }: SkillsFormProps) {
                 onClick={(e) => {
                   e.preventDefault();
                   moveSkillDown(index);
+                  setFormChanged(true);
+                  setStatusMessage("There has been a change. Don't forget to save!");
                 }}
                 className="bg-gray-400 text-white px-2 rounded hover:bg-gray-500 disabled:opacity-50 cursor-pointer"
                 disabled={index === skillsList.length - 1}
@@ -110,18 +163,26 @@ function SkillsForm({ skillsList, setSkillsList, user }: SkillsFormProps) {
               name={`skill-${index}`}
               placeholder="Enter a skill here"
               value={field}
-              onChange={(event) => handleChange(index, event.target.value)}
+              onChange={(event) => {
+                handleChange(index, event.target.value);
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to save!");
+              }}
               className="flex-grow p-2 border rounded"
             />
             <button
-              onClick={(event) => removeSkill(event, index)}
+              onClick={(event) => {
+                removeSkill(event, index);                
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to save!");
+              }}
               className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600 cursor-pointer"
             >
               ✕
             </button>
           </div>
         ))}
-
+        {statusMessage == "There has been a change. Don't forget to save!" && <p className="mt-2 text-sm text-yellow-400">{statusMessage}</p>}
         <button
           onClick={addNewSkill}
           className="bg-blue-500 text-white px-4 py-2 mt-2 rounded hover:bg-blue-600 cursor-pointer"
@@ -136,7 +197,8 @@ function SkillsForm({ skillsList, setSkillsList, user }: SkillsFormProps) {
         >
           {isSubmitting ? "Saving..." : "Save"}
         </button>
-        {statusMessage && <p className="mt-2 text-sm text-green-700">{statusMessage}</p>}
+        {statusMessage == "Saved!" && <p className="mt-2 text-sm text-green-700">{statusMessage}</p>}
+        {statusMessage == "Failed to save." && <p className="mt-2 text-sm text-red-600">{statusMessage}</p>}
       </form>
     </div>
   );

--- a/src/app/home/edit-summary/page.tsx
+++ b/src/app/home/edit-summary/page.tsx
@@ -12,6 +12,8 @@ export default function EditSummaryPage() {
   const [summary, setSummary] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [formChanged, setFormChanged] = useState(false); //for unsaved changes check
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (!loading && user) {
@@ -59,7 +61,56 @@ export default function EditSummaryPage() {
     const text = (formObj.summary as string).trim();
     setSummary(text);
     submitSummary(text);
+    setFormChanged(false);  // Lets page know change has been saved
+    setTimeout(() => setStatusMessage(null), 1); // Removes "unsaved change" from page
   }
+
+    useEffect(() => {
+    //handles reload and close tab if there are unsaved changes
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (formChanged) {
+        event.preventDefault();
+        event.returnValue = ''; //is deprecated but might be necessary to prompt on Chrome
+      }
+    };
+
+    //handles (most) clicks on links within the page if there are unsaved changes
+    const handleClick = (event: MouseEvent) => {
+      if (!formChanged) return;
+
+      const nav = document.querySelector('nav');
+      if (nav && nav.contains(event.target as Node)) {
+        const target = (event.target as HTMLElement).closest('a');
+        if (target && target instanceof HTMLAnchorElement) {
+          const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+        }
+      }
+
+      const header = document.querySelector('header');
+      if (header && header.contains(event.target as Node)) {
+        const target = (event.target as HTMLElement).closest('a');
+        if (target && target instanceof HTMLAnchorElement) {
+          const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+        }
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('click', handleClick, true);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [formChanged]);
 
   if (loading) {
     return <p>Loading...</p>;
@@ -74,10 +125,16 @@ export default function EditSummaryPage() {
             name="summary"
             placeholder="Enter your professional summary (or your career objectives) here"
             value={summary}
-            onChange={(e) => setSummary(e.target.value)}
+            onChange={(e) => {
+              setSummary(e.target.value);
+              setFormChanged(true);
+              setStatusMessage("There has been a change. Don't forget to save!");
+            }}
             rows={6}
             className="w-full p-3 border border-gray-300 rounded-md mb-4"
           />
+          {statusMessage == "There has been a change. Don't forget to save!" && <p className="mt-2 text-sm text-yellow-400">{statusMessage}</p>}
+          <br />
           <button
                 type="submit"
                 disabled={submitting}

--- a/src/app/home/edit-work-experience/page.tsx
+++ b/src/app/home/edit-work-experience/page.tsx
@@ -22,6 +22,10 @@ type ResponsibilitiesFormProps = {
 };
 
 function ResponsibilitiesForm({ resList, setResList, jobIdx }: ResponsibilitiesFormProps) {
+    const [statusMessage, setStatusMessage] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [formChanged, setFormChanged] = useState(false); //for unsaved changes check
+
     function handleChange(index: number, value: string) {
         setResList(
             resList.map((res, i) => (i === index ? value : res))
@@ -38,6 +42,64 @@ function ResponsibilitiesForm({ resList, setResList, jobIdx }: ResponsibilitiesF
         setResList(resList.filter((_, i) => i !== index));
     }
 
+    function placeboSubmit() { //all this does is reset formChanged and statusMessage so unchanged edits can be set & reset
+        try {
+            setIsSubmitting(true);
+            setStatusMessage("Saved!");
+            setFormChanged(false);
+            setTimeout(() => setStatusMessage(null), 2000);
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    useEffect(() => {
+        //handles reload and close tab if there are unsaved changes
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            if (formChanged) {
+                event.preventDefault();
+                event.returnValue = ''; //is deprecated but might be necessary to prompt on Chrome
+            }
+        };
+
+        //handles (most) clicks on links within the page if there are unsaved changes
+        const handleClick = (event: MouseEvent) => {
+            if (!formChanged) return;
+
+            const nav = document.querySelector('nav');
+            if (nav && nav.contains(event.target as Node)) {
+                const target = (event.target as HTMLElement).closest('a');
+                if (target && target instanceof HTMLAnchorElement) {
+                    const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+                    if (!confirmed) {
+                        event.preventDefault();
+                        event.stopImmediatePropagation();
+                    }
+                }
+            }
+
+            const header = document.querySelector('header');
+            if (header && header.contains(event.target as Node)) {
+                const target = (event.target as HTMLElement).closest('a');
+                if (target && target instanceof HTMLAnchorElement) {
+                    const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+                    if (!confirmed) {
+                        event.preventDefault();
+                        event.stopImmediatePropagation();
+                    }
+                }
+            }
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        document.addEventListener('click', handleClick, true);
+
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+            document.removeEventListener('click', handleClick, true);
+        };
+    }, [formChanged]);
+
     return (
         <>
             <h3 className="text-md font-semibold mt-4">Responsibilities:</h3>
@@ -49,17 +111,37 @@ function ResponsibilitiesForm({ resList, setResList, jobIdx }: ResponsibilitiesF
                         name={`responsibilities_${idx}_job_${jobIdx}`}
                         placeholder="Enter a responsibility here"
                         value={res}
-                        onChange={(e) => handleChange(idx, e.target.value)}
+                        onChange={(e) => {
+                            handleChange(idx, e.target.value);
+                            setFormChanged(true);
+                            setStatusMessage("There has been a change. Don't forget to click \"Save Responsibility\" and then the \"Save\" button at the bottom!");
+                        }}
                         className="border rounded w-full p-2"
                     />
-                    <button onClick={(e) => removeRes(e, idx)} className="bg-red-500 text-white px-3 py-1 mt-2 rounded hover:bg-red-600 cursor-pointer">
+                    <button onClick={(e) => {
+                        removeRes(e, idx);
+                        setFormChanged(true);
+                        setStatusMessage("There has been a change. Don't forget to click \"Save Responsibility\" and then the \"Save\" button at the bottom!");
+                    }} className="bg-red-500 text-white px-3 py-1 mt-2 rounded hover:bg-red-600 cursor-pointer">
                         Remove
                     </button>
                 </div>
             ))}
+            {statusMessage == "There has been a change. Don't forget to click \"Save Responsibility\" and then the \"Save\" button at the bottom!" && <p className="mt-2 text-sm text-yellow-400">{statusMessage}</p>}
             <button onClick={addRes} className="bg-blue-500 text-white px-4 py-2 mt-4 rounded hover:bg-blue-600 cursor-pointer">
                 Add Responsibility
             </button>
+            <br />
+            {/*PLACEBO BUTTON USED TO RESET FORMEDCHANGES, DOESN'T ACTUALLY SAVE ANYTHING IN THE BACKEND*/}
+            <button
+                type="button"
+                className="submit-button bg-green-500 text-white px-6 py-2 mt-4 rounded hover:bg-green-600 cursor-pointer disabled:opacity-50"
+                disabled={isSubmitting}
+                onClick={placeboSubmit}
+            > 
+                {isSubmitting ? "Saving..." : "Save Responsibility"}
+            </button>
+            {statusMessage == "Saved!" && <p className="mt-2 text-sm text-green-700">{statusMessage}</p>}
         </>
     );
 }
@@ -71,9 +153,10 @@ type WorkExpFormProps = {
 };
 
 function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
-    const [isSubmitting, setIsSubmitting] = useState(false);
     const [statusMessage, setStatusMessage] = useState<string | null>(null);
-
+    const [formChanged, setFormChanged] = useState(false); //for unsaved changes check
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    
     function updateJobAt(index: number, updatedJob: JobEntry) {
         const newList = [...jobList];
         newList[index] = updatedJob;
@@ -101,6 +184,7 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
             const docRef = doc(db, "users", user.uid);
             await updateDoc(docRef, { "resumeFields.workExperience": newJobList });
             setStatusMessage("Saved!");
+            setFormChanged(false);
             setTimeout(() => setStatusMessage(null), 2000);
         } catch (err) {
             setStatusMessage("Failed to save.");
@@ -132,6 +216,53 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
         setJobList(jobList.filter((_, i) => i !== index));
     }
 
+    useEffect(() => {
+        //handles reload and close tab if there are unsaved changes
+        const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+            if (formChanged) {
+                event.preventDefault();
+                event.returnValue = ''; //is deprecated but might be necessary to prompt on Chrome
+            }
+        };
+
+        //handles (most) clicks on links within the page if there are unsaved changes
+        const handleClick = (event: MouseEvent) => {
+            if (!formChanged) return;
+
+            const nav = document.querySelector('nav');
+            if (nav && nav.contains(event.target as Node)) {
+                const target = (event.target as HTMLElement).closest('a');
+                if (target && target instanceof HTMLAnchorElement) {
+                    const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+                    if (!confirmed) {
+                        event.preventDefault();
+                        event.stopImmediatePropagation();
+                    }
+                }
+            }
+
+            const header = document.querySelector('header');
+            if (header && header.contains(event.target as Node)) {
+                const target = (event.target as HTMLElement).closest('a');
+                if (target && target instanceof HTMLAnchorElement) {
+                    const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+                    if (!confirmed) {
+                        event.preventDefault();
+                        event.stopImmediatePropagation();
+                    }
+                }
+            }
+        };
+
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        document.addEventListener('click', handleClick, true);
+
+        return () => {
+            window.removeEventListener('beforeunload', handleBeforeUnload);
+            document.removeEventListener('click', handleClick, true);
+        };
+    }, [formChanged]);
+
     return (
         <form onSubmit={handleSubmit} className="space-y-8">
             {jobList.map((job, i) => (
@@ -143,7 +274,11 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
                         name={`jobTitle_${i}`}
                         placeholder="Job Title"
                         value={job.jobTitle}
-                        onChange={(e) => updateJobAt(i, { ...job, jobTitle: e.target.value })}
+                        onChange={(e) => {
+                            updateJobAt(i, { ...job, jobTitle: e.target.value });
+                            setFormChanged(true);
+                            setStatusMessage("There has been a change. Don't forget to save!");
+                        }}
                         className="w-full p-2 mb-2 border rounded"
                     />
                     <input
@@ -151,14 +286,22 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
                         name={`company_${i}`}
                         placeholder="Company"
                         value={job.company}
-                        onChange={(e) => updateJobAt(i, { ...job, company: e.target.value })}
+                        onChange={(e) => {
+                            updateJobAt(i, { ...job, company: e.target.value });
+                            setFormChanged(true);
+                            setStatusMessage("There has been a change. Don't forget to save!");
+                        }}
                         className="w-full p-2 mb-2 border rounded"
                     />
                     <textarea
                         name={`jobSummary_${i}`}
                         placeholder="Summary of your role"
                         value={job.jobSummary}
-                        onChange={(e) => updateJobAt(i, { ...job, jobSummary: e.target.value })}
+                        onChange={(e) => {
+                            updateJobAt(i, { ...job, jobSummary: e.target.value });
+                            setFormChanged(true);
+                            setStatusMessage("There has been a change. Don't forget to save!");
+                        }}
                         className="w-full p-2 mb-2 border rounded h-24"
                     />
                     <input
@@ -168,7 +311,11 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
                         value={job.startDate}
                         pattern="\d{4}-\d{2}"
                         title="Format: YYYY-MM"
-                        onChange={(e) => updateJobAt(i, { ...job, startDate: e.target.value })}
+                        onChange={(e) => {
+                            updateJobAt(i, { ...job, startDate: e.target.value });
+                            setFormChanged(true);
+                            setStatusMessage("There has been a change. Don't forget to save!");
+                        }}
                         className="w-full p-2 mb-2 border rounded"
                     />
                     <input
@@ -178,7 +325,11 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
                         value={job.endDate}
                         pattern="(\d{4}-\d{2}|Present)"
                         title="Format: YYYY-MM or Present"
-                        onChange={(e) => updateJobAt(i, { ...job, endDate: e.target.value })}
+                        onChange={(e) => {
+                            updateJobAt(i, { ...job, endDate: e.target.value });
+                            setFormChanged(true);
+                            setStatusMessage("There has been a change. Don't forget to save!");
+                        }}
                         className="w-full p-2 mb-2 border rounded"
                     />
 
@@ -189,11 +340,15 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
                         }
                         jobIdx={i}
                     />
-                    <div className="flex space-x-2 mt-4">
+                    <br />
+                    <br />
+                    <div className="flex space-x-2 mt-4">                        
                         <button
                             onClick={(e) => {
                                 e.preventDefault();
                                 moveJobUp(i);
+                                setFormChanged(true);
+                                setStatusMessage("There has been a change. Don't forget to save!");
                             }}
                             className="bg-gray-500 text-white px-3 py-1 rounded hover:bg-gray-600 disabled:opacity-50 cursor-pointer"
                             disabled={i === 0}
@@ -204,6 +359,8 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
                             onClick={(e) => {
                                 e.preventDefault();
                                 moveJobDown(i);
+                                setFormChanged(true);
+                                setStatusMessage("There has been a change. Don't forget to save!");
                             }}
                             className="bg-gray-500 text-white px-3 py-1 rounded hover:bg-gray-600 disabled:opacity-50 cursor-pointer"
                             disabled={i === jobList.length - 1}
@@ -214,7 +371,11 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
 
                     <div>
                         <button
-                            onClick={(e) => removeJob(e, i)}
+                            onClick={(e) => {
+                                removeJob(e, i);
+                                setFormChanged(true);
+                                setStatusMessage("There has been a change. Don't forget to save!");
+                            }}
                             className="bg-red-500 text-white px-3 py-1 mt-2 rounded hover:bg-red-600 cursor-pointer"
                         >
                             Remove Job
@@ -229,7 +390,7 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
             >
                 Add New Job
             </button>
-
+            {statusMessage == "There has been a change. Don't forget to save!" && <p className="mt-2 text-sm text-yellow-400">{statusMessage}</p>}
             <div>
                 <button
                     type="submit"
@@ -238,9 +399,8 @@ function WorkExpForm({ jobList, setJobList, user }: WorkExpFormProps) {
                 >
                     {isSubmitting ? "Saving..." : "Save"}
                 </button>
-                {statusMessage && (
-                    <p className="mt-2 text-green-600 dark:text-green-400">{statusMessage}</p>
-                )}
+                {statusMessage == "Saved!" && <p className="mt-2 text-green-600 dark:text-green-400">{statusMessage}</p>}
+                {statusMessage == "Failed to save." && <p className="mt-2 text-sm text-red-600">{statusMessage}</p>}
             </div>
         </form>
     );


### PR DESCRIPTION
Relevant Jira Ticket:
SCRUM-123: Notify user of unsaved changes on edit info pages

Note: for "Edit Work Experiences" page, there needed to be 2 buttons just to ensure that the "unsaved pages" blocker doesn't persist when the page is saved at the backend. The "Save Responsibilities" button removes the blocker for the Responsibilities parts affected by that function while the real "Save" button saves everything to the backend and removes the blocker for the inputs in the rest of the page. User is instructed to save with both buttons so that the info is still saved on the backend despite the work around. Had to do it this way because I did not want to mess with how the functions interact with the Gemini API as is and cause massive bugs. "Save Responsibilities" button is tagged as PLACEBO BUTTON in code