### PR TITLE
Twig chidi - 06/30/2025 Development - Update Page Titles and Edit Info Unsaved Changes Visualization

### DIFF
--- a/src/app/home/edit-contact-info/page.tsx
+++ b/src/app/home/edit-contact-info/page.tsx
@@ -16,6 +16,10 @@ type EmailFormProps = {
 };
 
 function EmailForm({emailList, setEmailList, submitted, setSubmitted, error, setError}: EmailFormProps) {
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formChanged, setFormChanged] = useState(false); //for unsaved changes check
+
   function handleChange(index: number, value: string) {
     if (submitted) setSubmitted(false); // Hide success message if editing again
     if (error) setError(null);          // Clear error message on user change
@@ -39,6 +43,66 @@ function EmailForm({emailList, setEmailList, submitted, setSubmitted, error, set
     // Remove the email from the array
     setEmailList((oldEmails) => oldEmails.filter((currEmail, i) => i !== index));
   }
+
+  function placeboSubmit() { //all this does is reset formChanged and statusMessage so unchanged edits can be set & reset
+    try {
+        setIsSubmitting(true);
+        setStatusMessage("Saved!");
+        setFormChanged(false);
+        setTimeout(() => setStatusMessage(null), 2000);
+    } finally {
+        setIsSubmitting(false);
+    }
+  }
+
+  useEffect(() => {
+    //handles reload and close tab if there are unsaved changes
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+        if (formChanged) {
+            event.preventDefault();
+            event.returnValue = ''; //is deprecated but might be necessary to prompt on Chrome
+        }
+    };
+
+    //handles (most) clicks on links within the page if there are unsaved changes
+    const handleClick = (event: MouseEvent) => {
+        if (!formChanged) return;
+
+        const nav = document.querySelector('nav');
+        if (nav && nav.contains(event.target as Node)) {
+            const target = (event.target as HTMLElement).closest('a');
+            if (target && target instanceof HTMLAnchorElement) {
+                const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+                if (!confirmed) {
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                }
+            }
+        }
+
+        const header = document.querySelector('header');
+        if (header && header.contains(event.target as Node)) {
+            const target = (event.target as HTMLElement).closest('a');
+            if (target && target instanceof HTMLAnchorElement) {
+                const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+                if (!confirmed) {
+                    event.preventDefault();
+                    event.stopImmediatePropagation();
+                }
+            }
+        }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('click', handleClick, true);
+
+    return () => {
+        window.removeEventListener('beforeunload', handleBeforeUnload);
+        document.removeEventListener('click', handleClick, true);
+    };
+  }, [formChanged]);
+
+
   return (
     <>
       <h2 className="text-l font-bold">Email Address:</h2>
@@ -49,18 +113,42 @@ function EmailForm({emailList, setEmailList, submitted, setSubmitted, error, set
             name="email"
             value={email}
             pattern="^[a-zA-Z0-9.!#$%&'*\+\/=?^_`\{\|\}~\-]+@[a-zA-Z0-9\-]+(\.[a-zA-Z0-9\-]+)+$"
-            onChange={(event) => handleChange(emailIdx, event.target.value)}
+            onChange={(event) => {
+              handleChange(emailIdx, event.target.value);
+              setFormChanged(true);
+              setStatusMessage("There has been a change. Don't forget to click \"Save Email Address\" and then the \"Save\" button at the bottom!");
+            }}
             placeholder="Enter your email address here"
             className="border p-2 rounded w-full"
           />
           <button
             className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600 cursor-pointer"
-            onClick={(event) => removeEmail(event, emailIdx)}>Remove</button><br></br>
+            onClick={(event) => {
+              removeEmail(event, emailIdx);
+              setFormChanged(true);
+              setStatusMessage("There has been a change. Don't forget to click \"Save Email Address\" and then the \"Save\" button at the bottom!");
+            }}>
+              Remove
+              </button><br />
         </div>
       ))}
+      {statusMessage == "There has been a change. Don't forget to click \"Save Email Address\" and then the \"Save\" button at the bottom!" && <p className="mt-2 text-sm text-yellow-400">{statusMessage}</p>} 
       <button
-        className="bg-blue-500 text-white px-4 py-2 mt-2 rounded hover:bg-blue-600 cursor-pointer"
-        onClick={addEmail}>Add New Email Address</button>
+        className="bg-blue-500 text-white px-3 py-2 mt-2 rounded hover:bg-blue-600 cursor-pointer" 
+        onClick={addEmail}
+      >
+        Add New Email Address
+      </button>
+      {/*PLACEBO BUTTON USED TO RESET FORMEDCHANGES, DOESN'T ACTUALLY SAVE ANYTHING IN THE BACKEND*/}
+      <button
+          type="button"
+          className="submit-button bg-green-500 text-white px-3 py-2 mt-4 rounded hover:bg-green-600 cursor-pointer disabled:opacity-50"
+          disabled={isSubmitting}
+          onClick={placeboSubmit}
+      > 
+      {isSubmitting ? "Saving..." : "Save Email Address"}
+      </button>
+      {statusMessage == "Saved!" && <p className="mt-2 text-sm text-green-700">{statusMessage}</p>}
     </>
   );
 }
@@ -75,6 +163,10 @@ type PhoneNumFormProps = {
 };
 
 function PhoneNumForm({phoneList, setPhoneList, submitted, setSubmitted, error, setError}: PhoneNumFormProps) {
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formChanged, setFormChanged] = useState(false); //for unsaved changes check
+
   function handleChange(index: number, value: string) {
     if (submitted) setSubmitted(false); // Hide success message if editing again
     if (error) setError(null);          // Clear error message on user change
@@ -99,6 +191,64 @@ function PhoneNumForm({phoneList, setPhoneList, submitted, setSubmitted, error, 
     setPhoneList((oldNums) => oldNums.filter((currNum, i) => i !== index));
   }
 
+  function placeboSubmit() { //all this does is reset formChanged and statusMessage so unchanged edits can be set & reset
+        try {
+            setIsSubmitting(true);
+            setStatusMessage("Saved!");
+            setFormChanged(false);
+            setTimeout(() => setStatusMessage(null), 2000);
+        } finally {
+            setIsSubmitting(false);
+        }
+    }
+
+    useEffect(() => {
+      //handles reload and close tab if there are unsaved changes
+      const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+          if (formChanged) {
+              event.preventDefault();
+              event.returnValue = ''; //is deprecated but might be necessary to prompt on Chrome
+          }
+      };
+
+      //handles (most) clicks on links within the page if there are unsaved changes
+      const handleClick = (event: MouseEvent) => {
+        if (!formChanged) return;
+
+        const nav = document.querySelector('nav');
+        if (nav && nav.contains(event.target as Node)) {
+          const target = (event.target as HTMLElement).closest('a');
+          if (target && target instanceof HTMLAnchorElement) {
+            const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+            if (!confirmed) {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+            }
+              }
+          }
+
+          const header = document.querySelector('header');
+          if (header && header.contains(event.target as Node)) {
+              const target = (event.target as HTMLElement).closest('a');
+              if (target && target instanceof HTMLAnchorElement) {
+                  const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+                  if (!confirmed) {
+                      event.preventDefault();
+                      event.stopImmediatePropagation();
+                  }
+              }
+          }
+      };
+
+      window.addEventListener('beforeunload', handleBeforeUnload);
+      document.addEventListener('click', handleClick, true);
+
+      return () => {
+          window.removeEventListener('beforeunload', handleBeforeUnload);
+          document.removeEventListener('click', handleClick, true);
+      };
+    }, [formChanged]);
+
   return (
     <>
       <h2 className="text-l font-bold">Phone Number (Format: 123-456-7890):</h2>
@@ -109,18 +259,43 @@ function PhoneNumForm({phoneList, setPhoneList, submitted, setSubmitted, error, 
             name="phone"
             pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}"
             value={phoneNum}
-            onChange={(event) => handleChange(phoneIdx, event.target.value)}
-            placeholder="Enter your number here"
+            onChange={(event) => {
+              handleChange(phoneIdx, event.target.value);
+                setFormChanged(true);
+                setStatusMessage("There has been a change. Don't forget to click \"Save Phone Number\" and then the \"Save\" button at the bottom!");
+            }}
+            placeholder="Enter your phone number here"
             className="border p-2 rounded w-full"
           />
           <button
             className="bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600 cursor-pointer"
-            onClick={(event) => removePhoneNum(event, phoneIdx)}>Remove</button><br></br>
+            onClick={(event) => {
+              removePhoneNum(event, phoneIdx);
+              setFormChanged(true);
+              setStatusMessage("There has been a change. Don't forget to click \"Save Phone Number\" and then the \"Save\" button at the bottom!");
+            }}
+          >
+            Remove
+          </button><br />
         </div>
       ))}
+      {statusMessage == "There has been a change. Don't forget to click \"Save Phone Number\" and then the \"Save\" button at the bottom!" && <p className="mt-2 text-sm text-yellow-400">{statusMessage}</p>}
       <button
-        className="bg-blue-500 text-white px-4 py-2 mt-2 rounded hover:bg-blue-600 cursor-pointer"
-        onClick={addPhoneNum}>Add New Phone Number</button>
+        className="bg-blue-500 text-white px-3 py-2 mt-2 rounded hover:bg-blue-600 cursor-pointer"
+        onClick={addPhoneNum}
+      >
+        Add New Phone Number
+      </button>
+      {/*PLACEBO BUTTON USED TO RESET FORMEDCHANGES, DOESN'T ACTUALLY SAVE ANYTHING IN THE BACKEND*/}
+      <button
+          type="button"
+          className="submit-button bg-green-500 text-white px-3 py-2 mt-4 rounded hover:bg-green-600 cursor-pointer disabled:opacity-50"
+          disabled={isSubmitting}
+          onClick={placeboSubmit}
+      > 
+          {isSubmitting ? "Saving..." : "Save Responsibility"}
+      </button>
+      {statusMessage == "Saved!" && <p className="mt-2 text-sm text-green-700">{statusMessage}</p>}
     </>
   );
 }
@@ -137,6 +312,9 @@ export default function EditContactInfoPage() {
   const [submitting, setSubmitting] = useState(false); // Tracks if form is being submitted
   const [submitted, setSubmitted] = useState(false); // Tracks if submission succeeded
   const [error, setError] = useState<string | null>(null); // Stores error message for display
+  
+  const [formChanged, setFormChanged] = useState(false); //for unsaved changes check
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
 
   useEffect(() => {
     if (!loading && user) {
@@ -195,12 +373,62 @@ export default function EditContactInfoPage() {
 
       setSubmitting(false); // Hide spinner
       setSubmitted(true);   // Trigger visual success feedback
+      setFormChanged(false);  // Lets page know change has been saved
+      setTimeout(() => setStatusMessage(null), 1); // Removes "unsaved change" from page and resets after 3s
+      setTimeout(() => setSubmitted(false), 3000);
     } catch (err: any) {
       console.error("Error updating contact info:", err);
       setError("Something went wrong. Please try again."); // Show error feedback
       setSubmitting(false); // Stop spinner if error occurs
     }
   }
+
+  useEffect(() => {
+    //handles reload and close tab if there are unsaved changes
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (formChanged) {
+        event.preventDefault();
+        event.returnValue = ''; //is deprecated but might be necessary to prompt on Chrome
+      }
+    };
+
+    //handles (most) clicks on links within the page if there are unsaved changes
+    const handleClick = (event: MouseEvent) => {
+      if (!formChanged) return;
+
+      const nav = document.querySelector('nav');
+      if (nav && nav.contains(event.target as Node)) {
+        const target = (event.target as HTMLElement).closest('a');
+        if (target && target instanceof HTMLAnchorElement) {
+          const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+        }
+      }
+
+      const header = document.querySelector('header');
+      if (header && header.contains(event.target as Node)) {
+        const target = (event.target as HTMLElement).closest('a');
+        if (target && target instanceof HTMLAnchorElement) {
+          const confirmed = window.confirm('You have unsaved changes. Leave this page?');
+          if (!confirmed) {
+            event.preventDefault();
+            event.stopImmediatePropagation();
+          }
+        }
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('click', handleClick, true);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('click', handleClick, true);
+    };
+  }, [formChanged]);
 
   // Reset success and error states when user edits any field
   function handleInputChange(
@@ -210,6 +438,8 @@ export default function EditContactInfoPage() {
       setter(e.target.value);
       if (submitted) setSubmitted(false); // Hide success message if editing again
       if (error) setError(null);          // Clear error message on user change
+      setFormChanged(true);               // Shows that form is changed
+      setStatusMessage("There has been a change. Don't forget to save!"); // Visual affirmation of change
     };
   }
 
@@ -259,7 +489,7 @@ export default function EditContactInfoPage() {
         placeholder="Enter your location here"
         className="border p-2 rounded w-full"
       />
-
+      {statusMessage == "There has been a change. Don't forget to save!" && <p className="mt-2 text-sm text-yellow-400">{statusMessage}</p>}
       {/* SUBMIT BUTTON with dynamic styles for submitting and submitted states */}
       <button
         type="submit"

--- a/src/app/home/view-past-uploads/page.tsx
+++ b/src/app/home/view-past-uploads/page.tsx
@@ -359,7 +359,7 @@ export default function ViewPastUploadsPage() {
           <AccordionItem key={i} value={`item-${i}`} className="flex flex-col justify-between mb-8">
             {/* <AccordionTrigger>{f.name} <GetFileDate fileRef={f}></GetFileDate></AccordionTrigger> */}
             <AccordionTrigger>
-              <div className="cursor-pointer text-lg transition-duration-400 hover:bg-muted-foreground">
+              <div className="cursor-pointer text-lg transition-duration-400 hover:bg-chart-2">
                 {f.name}
                 <GetFileDate fileRef={f}></GetFileDate>
               </div>

--- a/src/app/home/view-past-uploads/page.tsx
+++ b/src/app/home/view-past-uploads/page.tsx
@@ -2,6 +2,7 @@
 import { useAuth } from "@/context/authContext";
 import { useRouter } from "next/navigation";
 import { useState, useEffect, useRef } from "react";
+import React from "react";
 import { ref, list, getDownloadURL, StorageReference, deleteObject, getMetadata, FullMetadata } from "firebase/storage";
 import { storage } from "@/lib/firebase";
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@radix-ui/react-accordion";
@@ -9,6 +10,7 @@ import { renderAsync } from "docx-preview";
 import JSZip from "jszip";
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogOverlay, DialogPortal, DialogTitle, DialogTrigger } from "@radix-ui/react-dialog";
 import { metadata } from "@/app/server-layout";
+import { Button } from "@/components/ui/button";
 
 // Types
 
@@ -261,15 +263,19 @@ function DeleteFileButton({fileRef, fileRefs, setFileRefs}: DeleteFileButtonProp
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <button type="button" disabled={deleting}>
+        <button
+          type="button"
+          disabled={deleting}
+          className="bg-red-500 px-2 py-1 rounded mt-3"
+        >
           {deleting ? "Deleting..." : "Delete"}
         </button>
       </DialogTrigger>
       <DialogPortal>
-          <DialogOverlay className="fixed inset-0 bg-black bg-opacity-50"></DialogOverlay>
-            <DialogContent className="fixed top-1/2 left-1/2 bg-white p-4 rounded shadow transform -translate-x-1/2 -translate-y-1/2">
-              <DialogTitle>Confirm Delete</DialogTitle>
-              <DialogDescription>
+          <DialogOverlay className="fixed inset-0 backdrop-blur-md bg-opacity-50"></DialogOverlay>
+            <DialogContent className="fixed top-1/2 left-1/2 bg-background p-4 rounded shadow transform -translate-x-1/2 -translate-y-1/2 border border-foreground">
+              <DialogTitle className="text-foreground"><strong><u>Confirm Delete</u></strong></DialogTitle>
+              <DialogDescription className="text-foreground">
                 Are you sure you want to delete <strong>{fileRef.name}</strong>?
               </DialogDescription>
               <div className="mt-4 flex gap-2">
@@ -281,7 +287,9 @@ function DeleteFileButton({fileRef, fileRefs, setFileRefs}: DeleteFileButtonProp
                   {deleting ? "Deleting..." : "Yes, Delete"}
                 </button>
                 <DialogClose asChild>
-                  <button className="bg-gray-300 px-2 py-1 rounded" disabled={deleting}>Cancel</button>
+                  <button className="bg-gray-600 px-2 py-1 rounded text-white" disabled={deleting}>
+                    Cancel
+                  </button>
                 </DialogClose>
               </div>
               {error && <div className="mt-2 text-red-500">{error}</div>}
@@ -344,20 +352,23 @@ export default function ViewPastUploadsPage() {
   }, [user, loading, router]);
 
   return (
-    <div>
-      <h1>View Past Uploads</h1>
+    <div className="flex flex-col items-center">
+      <h1 className="text-3xl m-auto font-bold mb-5"><u>View Past Uploads</u></h1>
       <Accordion type="single" collapsible className="w-full">
         {fileRefs.map((f, i) => (
-          <AccordionItem key={i} value={`item-${i}`}>
+          <AccordionItem key={i} value={`item-${i}`} className="flex flex-col justify-between mb-8">
             {/* <AccordionTrigger>{f.name} <GetFileDate fileRef={f}></GetFileDate></AccordionTrigger> */}
             <AccordionTrigger>
-              <div>{f.name}</div>
-              <GetFileDate fileRef={f}></GetFileDate>
+              <div className="cursor-pointer text-lg transition-duration-400 hover:bg-muted-foreground">
+                {f.name}
+                <GetFileDate fileRef={f}></GetFileDate>
+              </div>
             </AccordionTrigger>
-            <AccordionContent>
+            <AccordionContent className="flex flex-col gap-4 text-balance">
               <PreviewFile fileRef={f} />
               <DeleteFileButton fileRef={f} fileRefs={fileRefs} setFileRefs={setFileRefs} />
             </AccordionContent>
+            <hr className="mt-2 bg-foreground"/>
           </AccordionItem>
         ))}
       </Accordion>

--- a/src/components/topBanner.tsx
+++ b/src/components/topBanner.tsx
@@ -41,12 +41,15 @@ export default function TopBanner({ toggleSidePanel }: TopBannerProps) {
         "/home": "Home",
         "/home/settings": "Settings",
         "/home/upload-resume": "Upload Resume",
+        "/home/upload-job-ad": "Upload Job Ad",
+        "/home/view-job-ad": "View Job Ads",
         "/home/free-form": "Submit Freeform Text",
         "/home/edit-contact-info": "Edit Contact Info",
         "/home/edit-summary": "Edit Professional Summary",
         "/home/edit-skills": "Edit Skills",
         "/home/edit-education": "Edit Education",
         "/home/edit-work-experience": "Edit Work Experience",
+        "/home/view-past-uploads": "Past Uploads",
     };
 
     const pageTitle = pageTitles[pathname] || "Page"; // Default to "Page" if no match

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }


### PR DESCRIPTION
Relevant Jira Ticket:
SCRUM-123: Notify user of unsaved changes on edit info pages
SCRUM-152: Add some styling to the 'View Past Uploads' page
SCRUM-154: Add some styling to the 'Load Past Submissions' menu on the 'Write free-form' page

Note: for "Edit Work Experiences" page, there needed to be 2 buttons just to ensure that the "unsaved pages" blocker doesn't persist when the page is saved at the backend. The "Save Responsibilities" button removes the blocker for the Responsibilities parts affected by that function while the real "Save" button saves everything to the backend and removes the blocker for the inputs in the rest of the page. User is instructed to save with both buttons so that the info is still saved on the backend despite the work around. Had to do it this way because I did not want to mess with how the functions interact with the Gemini API as is and cause massive bugs. "Save Responsibilities" button is tagged as PLACEBO BUTTON in code

Same for the Phone Number and Email Address parts of the "Edit Contact Info" page; placebo buttons added for the same outcome