### PR TITLE
Edit Contact Info page typo

### DIFF
--- a/src/app/home/edit-contact-info/page.tsx
+++ b/src/app/home/edit-contact-info/page.tsx
@@ -293,7 +293,7 @@ function PhoneNumForm({phoneList, setPhoneList, submitted, setSubmitted, error, 
           disabled={isSubmitting}
           onClick={placeboSubmit}
       > 
-          {isSubmitting ? "Saving..." : "Save Responsibility"}
+          {isSubmitting ? "Saving..." : "Save Phone Number"}
       </button>
       {statusMessage == "Saved!" && <p className="mt-2 text-sm text-green-700">{statusMessage}</p>}
     </>


### PR DESCRIPTION
On the `Edit Contact Info` page, there was a small typo where the button for saving phone numbers said "Save Responsibility", so I changed it to say "Save Phone Number".